### PR TITLE
update README with `parse()` method

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,8 @@ Queries and determine if a media query matches a given set of values.
 
 ### Matching
 
-The `match()` method lets you compare a media query expression with a JavaScript object and determine if a media query matches a given set of values.
+The `match()` method lets you compare a media query expression with a JavaScript
+object and determine if a media query matches a given set of values.
 
 ```javascript
 var mediaQuery = require('css-mediaquery');
@@ -40,7 +41,9 @@ console.log(isMatch); // => true
 
 ### Parsing
 
-Existing CSS Parsers don't do a great job at parsing the details of media queries. That's where `css-mediaquery` shines. You can parse a media query expression and get an AST back by using the `parse()` method.
+Existing CSS Parsers don't do a great job at parsing the details of media
+queries. That's where `css-mediaquery` shines. You can parse a media query
+expression and get an AST back by using the `parse()` method.
 
 ```javascript
 
@@ -52,21 +55,9 @@ var ast = mediaQuery.parse('screen and (min-width: 48em)');
 The `ast` variable will have the following payload:
 
 ```javascript
-
-[
-    {
-        "inverse": false,
-        "type": "screen",
-        "expressions": [
-            {
-                "modifier": "min",
-                "feature": "width",
-                "value": "48em"
-            }
-        ]
-    }
-]
-
+[ { inverse: false, type: 'screen', expressions: [
+    { modifier: 'min', feature: 'width', value: '48em' }
+] } ]
 ```
 
 This package was written with care to following the W3C Recommendations for
@@ -76,7 +67,8 @@ a common unit before comparing them.
 
 
 The values specified to check a media query string against should be thought of
-as if they are the current state of a device/browser. A `type` value _must_ be specified, and it can _not_ be `"all"`.
+as if they are the current state of a device/browser. A `type` value _must_ be
+specified, and it can _not_ be `"all"`.
 
 
 [w3c-mq]: http://www.w3.org/TR/css3-mediaqueries/


### PR DESCRIPTION
Just some updates to the README to include information about the `parse()` method.
