### PR TITLE
css-mediaquery should strictly adhere to <media_types>

### DIFF
--- a/test/unit-tests.js
+++ b/test/unit-tests.js
@@ -53,6 +53,10 @@ describe('mediaQuery.parse()', function () {
         expect(parse('()')).to.throw(SyntaxError);
         expect(parse('(foo) (bar)')).to.throw(SyntaxError);
         expect(parse('(foo:) and (bar)')).to.throw(SyntaxError);
+
+        //These should fail
+        expect(parse('foo')).to.throw(SyntaxError);
+        expect(parse('foo and (max-width: 48em)')).to.throw(SyntaxError);
     });
 });
 


### PR DESCRIPTION
I added a passing test that should be failing. We should update `css-mediaquery` to strictly match valid media types when parsing. According to the [MDN docs](https://developer.mozilla.org/en-US/docs/Web/Guide/CSS/Media_queries), the valid media types are:

> media_type: all | aural | braille | handheld | print | projection | screen | tty | tv | embossed

This way, we could throw syntax errors if someone types something like `med=crap`. 

PS: According to the [spec](http://www.w3.org/TR/css3-mediaqueries/), unknown media types evaluate to false. Effectively, they are treated identically to known media types that do not match the media type of the device.
