### PR TITLE
fix: 0 length never matching

### DIFF
--- a/index.js
+++ b/index.js
@@ -37,7 +37,7 @@ function matchQuery(mediaQuery, values) {
                 value    = values[feature];
 
             // Missing or falsy values don't match.
-            if (!value) { return false; }
+            if (!value && value !== 0) { return false; }
 
             switch (feature) {
                 case 'orientation':

--- a/test/unit-tests.js
+++ b/test/unit-tests.js
@@ -158,6 +158,12 @@ describe('mediaQuery.match()', function () {
                     '(max-height: 1000px)', {height: '60pc'}
                 )).to.be.true;
             });
+
+            it('should work with literal 0', function () {
+                expect(mediaQuery.match(
+                    '(max-height: 1000px)', {height: 0}
+                )).to.be.true;
+            });
         });
 
     });


### PR DESCRIPTION
Since numeric values are accepted for width/height etc it's confusing to never match `0`.