### PR TITLE
Fixed package license identifier.

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
   "contributors": [
     "Tilo Mitra <tilomitra@gmail.com>"
   ],
-  "license": "BSD",
+  "license": "BSD-3-Clause",
   "bugs": {
     "url": "https://github.com/ericf/css-mediaquery/issues"
   },


### PR DESCRIPTION
I believe the LICENSE file content to be correctly identified by `BSD-3-Clause` SPDX identifier.